### PR TITLE
Doubles Event Cancellation Window for admins 

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,4 +1,4 @@
-#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME 10
+#define RANDOM_EVENT_ADMIN_INTERVENTION_TIME 20
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control


### PR DESCRIPTION
Its too hard to click on event cancellation prompt when admin logs are spamming at the speed of sound. I have missed event cancellations because I want to cancel it, but I don't make it on time. Or that I didn't realize because I had the audacity to look away or type for 5 seconds, and then only have a 5 second window to cancel. Doubles the event cancellation timer which doesn't really affect anything on the player's side, just lets admins more easily ward off events that really don't need to be spawned.

# Changelog

tweak: The Gods can more easily prevent station shattering events from happening before the consequences are ever known. 

